### PR TITLE
Support for WCF 4 Web Http Services

### DIFF
--- a/src/SharpArch/SharpArch.Wcf/NHibernate/WebServiceHost.cs
+++ b/src/SharpArch/SharpArch.Wcf/NHibernate/WebServiceHost.cs
@@ -1,0 +1,16 @@
+﻿using System.ServiceModel;
+using System;
+
+namespace SharpArch.Wcf.NHibernate
+{
+    public class WebServiceHost : System.ServiceModel.Web.WebServiceHost
+    {
+        public WebServiceHost(Type serviceType, params Uri[] baseAddresses) : base(serviceType, baseAddresses) { }
+
+        protected override void OnOpening()
+        {
+            Description.Behaviors.Add(new ServiceBehavior());
+            base.OnOpening();
+        }
+    }
+}

--- a/src/SharpArch/SharpArch.Wcf/NHibernate/WebServiceHostFactory.cs
+++ b/src/SharpArch/SharpArch.Wcf/NHibernate/WebServiceHostFactory.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace SharpArch.Wcf.NHibernate
+{
+    public class WebServiceHostFactory : System.ServiceModel.Activation.WebServiceHostFactory
+    {
+        protected override System.ServiceModel.ServiceHost CreateServiceHost(Type serviceType, Uri[] baseAddresses){
+            return new WebServiceHost(serviceType, baseAddresses);
+        }
+    }
+}

--- a/src/SharpArch/SharpArch.Wcf/SharpArch.Wcf.csproj
+++ b/src/SharpArch/SharpArch.Wcf/SharpArch.Wcf.csproj
@@ -68,6 +68,7 @@
     <Reference Include="System.ServiceModel">
       <RequiredTargetFramework>3.0</RequiredTargetFramework>
     </Reference>
+    <Reference Include="System.ServiceModel.Web" />
     <Reference Include="System.Xml.Linq">
       <RequiredTargetFramework>3.5</RequiredTargetFramework>
     </Reference>
@@ -82,6 +83,8 @@
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="ICloseableAndAbortable.cs" />
+    <Compile Include="NHibernate\WebServiceHost.cs" />
+    <Compile Include="NHibernate\WebServiceHostFactory.cs" />
     <Compile Include="ServiceLocatorInstanceProvider.cs" />
     <Compile Include="NHibernate\InstanceCreationInitializer.cs" />
     <Compile Include="NHibernate\DispatchMessageInspector.cs" />


### PR DESCRIPTION
I added the support for web http services using wcf 4.
The current version of sharp arch wasn't providing the new WebServiceHost/Factory in order to instantiate the new web http services correctly. 
I added the two classes (WebServiceHost & WebServiceHostFactory) which inherits from the .Net ones so it's now possible to specify this new factory for creating wcf 4 rest services having sharp arch initializing correctly all the nhibernate stuff. Hope you accept these changes and put them in the main project.
Any question you con contact me on my email address.

Regards

Alessandro Di Lello
