### PR TITLE
Add strongly typed command result to CommandProcessor/Handler

### DIFF
--- a/Solutions/SharpArch.Domain/Commands/CommandHandlerNotFoundException.cs
+++ b/Solutions/SharpArch.Domain/Commands/CommandHandlerNotFoundException.cs
@@ -8,5 +8,10 @@
             : base(string.Format("Command handler not found for command type: {0}", type))
         {
         }
+
+        public CommandHandlerNotFoundException(Type commandType, Type commandResult)
+            : base(string.Format("Command handler not found for command type: {0}, and command result type: {1}", commandType, commandResult))
+        {
+        }
     }
 }

--- a/Solutions/SharpArch.Domain/Commands/CommandProcessor.cs
+++ b/Solutions/SharpArch.Domain/Commands/CommandProcessor.cs
@@ -1,4 +1,7 @@
-﻿namespace SharpArch.Domain.Commands
+﻿using System;
+using System.Collections.Generic;
+
+namespace SharpArch.Domain.Commands
 {
     using System.ComponentModel.DataAnnotations;
     using System.Linq;
@@ -20,6 +23,30 @@
             foreach (var handler in handlers)
             {
                 handler.Handle(command);
+            }
+        }
+
+        public IEnumerable<TResult> Process<TCommand, TResult>(TCommand command) where TCommand : ICommand
+        {
+            Validator.ValidateObject(command, new ValidationContext(command, null, null), true);
+
+            var handlers = ServiceLocator.Current.GetAllInstances<ICommandHandler<TCommand, TResult>>();
+            if (handlers == null || !handlers.Any())
+            {
+                throw new CommandHandlerNotFoundException(typeof(TCommand));
+            }
+
+            foreach (var handler in handlers)
+            {
+                yield return handler.Handle(command);
+            }
+        }
+
+        public void Process<TCommand, TResult>(TCommand command, Action<TResult> resultHandler) where TCommand : ICommand
+        {
+            foreach (var result in Process<TCommand, TResult>(command))
+            {
+                resultHandler(result);
             }
         }
     }

--- a/Solutions/SharpArch.Domain/Commands/ICommandHandler.cs
+++ b/Solutions/SharpArch.Domain/Commands/ICommandHandler.cs
@@ -4,4 +4,9 @@
     {
         void Handle(TCommand command);
     }
+
+    public interface ICommandHandler<in TCommand, out TResult> where TCommand : ICommand
+    {
+        TResult Handle(TCommand command);
+    }
 }

--- a/Solutions/SharpArch.Domain/Commands/ICommandProcessor.cs
+++ b/Solutions/SharpArch.Domain/Commands/ICommandProcessor.cs
@@ -1,7 +1,14 @@
-﻿namespace SharpArch.Domain.Commands
+﻿using System;
+using System.Collections.Generic;
+
+namespace SharpArch.Domain.Commands
 {
     public interface ICommandProcessor
     {
         void Process<TCommand>(TCommand command) where TCommand : ICommand;
+
+        IEnumerable<TResult> Process<TCommand, TResult>(TCommand command) where TCommand : ICommand;
+
+        void Process<TCommand, TResult>(TCommand command, Action<TResult> resultHandler) where TCommand : ICommand;
     }
 }

--- a/Solutions/SharpArch.Tests/SharpArch.Domain/Commands/CommandProcessorTests.cs
+++ b/Solutions/SharpArch.Tests/SharpArch.Domain/Commands/CommandProcessorTests.cs
@@ -1,3 +1,5 @@
+using System.Linq;
+
 namespace Tests.SharpArch.Domain.Commands
 {
     using System.Collections.Generic;
@@ -81,6 +83,38 @@ namespace Tests.SharpArch.Domain.Commands
         }
 
         [Test]
+        public void CanHandleCommandWithResult()
+        {
+            container.Register(
+              Component.For<ICommandHandler<TestCommand, CommandResult<TestCommand>>>()
+                .UsingFactoryMethod(CreateCommandHandlerWithResult<TestCommand>)
+                .LifeStyle.Transient);
+
+            var testCommand = new TestCommand();
+            var results = commandProcessor.Process<TestCommand, CommandResult<TestCommand>>(testCommand).ToList();
+
+            Assert.AreEqual(1, results.Count);
+            Assert.AreEqual(testCommand, results[0].Command);
+        }
+
+        [Test]
+        public void CanHandleCommandWithResultDelegate()
+        {
+            container.Register(
+              Component.For<ICommandHandler<TestCommand, CommandResult<TestCommand>>>()
+                .UsingFactoryMethod(CreateCommandHandlerWithResult<TestCommand>)
+                .LifeStyle.Transient);
+
+            var testCommand = new TestCommand();
+            var results = new List<TestCommand>();
+            commandProcessor.Process<TestCommand, CommandResult<TestCommand>>(testCommand, c => results.Add(c.Command));
+
+            Assert.AreEqual(1, results.Count);
+            Assert.AreEqual(testCommand, results[0]);
+        }
+
+
+        [Test]
         public void CanHandleMultipleCommands()
         {
             container.Register(
@@ -107,6 +141,12 @@ namespace Tests.SharpArch.Domain.Commands
         {
             return new TestCommandHandler<TCommand>(OnHandle);
         }
+
+        private TestCommandHandlerWithResult<TCommand> CreateCommandHandlerWithResult<TCommand>() where TCommand : ICommand
+        {
+            return new TestCommandHandlerWithResult<TCommand>();
+        }
+
 
         private void OnHandle<TCommand>(ICommandHandler<TCommand> handler, TCommand command) where TCommand : ICommand
         {

--- a/Solutions/SharpArch.Tests/SharpArch.Domain/Commands/CommandResult.cs
+++ b/Solutions/SharpArch.Tests/SharpArch.Domain/Commands/CommandResult.cs
@@ -1,0 +1,9 @@
+namespace Tests.SharpArch.Domain.Commands
+{
+    public class CommandResult<T>
+    {
+        public bool Success { get; set; }
+
+        public T Command { get; set; }
+    }
+}

--- a/Solutions/SharpArch.Tests/SharpArch.Domain/Commands/TestCommandHandlerWithResult.cs
+++ b/Solutions/SharpArch.Tests/SharpArch.Domain/Commands/TestCommandHandlerWithResult.cs
@@ -1,0 +1,12 @@
+using SharpArch.Domain.Commands;
+
+namespace Tests.SharpArch.Domain.Commands
+{
+    public class TestCommandHandlerWithResult<TCommand> : ICommandHandler<TCommand, CommandResult<TCommand>> where TCommand : ICommand
+    {
+        public CommandResult<TCommand> Handle(TCommand command)
+        {
+            return new CommandResult<TCommand> { Command = command, Success = true };
+        }
+    }
+}

--- a/Solutions/SharpArch.Tests/SharpArch.Tests.csproj
+++ b/Solutions/SharpArch.Tests/SharpArch.Tests.csproj
@@ -134,10 +134,12 @@
     </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SharpArch.Domain\Commands\CommandProcessorTests.cs" />
+    <Compile Include="SharpArch.Domain\Commands\CommandResult.cs" />
     <Compile Include="SharpArch.Domain\Commands\CommandTests.cs" />
     <Compile Include="SharpArch.Domain\Commands\InvalidCommand.cs" />
     <Compile Include="SharpArch.Domain\Commands\TestCommand.cs" />
     <Compile Include="SharpArch.Domain\Commands\TestCommandHandler.cs" />
+    <Compile Include="SharpArch.Domain\Commands\TestCommandHandlerWithResult.cs" />
     <Compile Include="SharpArch.Domain\Commands\ValidCommand.cs" />
     <Compile Include="SharpArch.Domain\DataAnnotationsValidator\HasUniqueEntitySignatureValidatorTests.cs" />
     <Compile Include="SharpArch.Domain\DesignByContractTests.cs" />


### PR DESCRIPTION
I'm not sure why CommandResult was removed from the trunk, I didn't really like it either, but it was useful. :)

Anyway, I need to be able to return command results from my handlers, so I have re-implemented them in a strongly typed manner.

This pull request adds these two methods to ICommandProcessor:

```
IEnumerable<TResult> Process<TCommand, TResult>(TCommand command) where TCommand : ICommand;
void Process<TCommand, TResult>(TCommand command, Action<TResult> resultHandler) where TCommand : ICommand;
```

Usage:

```
var results = _commandProcessor.Process<UserSignupCommand, UserSignupResult>(command);
```

Let me know if this is not something you guys had in mind to support for some reason.
