### PR TITLE
Decorated the attribute classes with the AttributeUsageAttribute, to restrict usage of the attributes to their intended targets.

### DIFF
--- a/Solutions/SharpArch.Domain/DomainModel/DomainSignatureAttribute.cs
+++ b/Solutions/SharpArch.Domain/DomainModel/DomainSignatureAttribute.cs
@@ -10,6 +10,7 @@ namespace SharpArch.Domain.DomainModel
     ///     This is intended for use with <see cref = "Entity" />.  It may NOT be used on a <see cref = "ValueObject" />.
     /// </remarks>
     [Serializable]
+    [AttributeUsage(AttributeTargets.Property, AllowMultiple = false)]
     public class DomainSignatureAttribute : Attribute
     {
     }

--- a/Solutions/SharpArch.NHibernate/NHibernateValidator/HasUniqueDomainSignatureAttribute.cs
+++ b/Solutions/SharpArch.NHibernate/NHibernateValidator/HasUniqueDomainSignatureAttribute.cs
@@ -1,5 +1,6 @@
 ﻿namespace SharpArch.NHibernate.NHibernateValidator
 {
+    using System;
     using System.ComponentModel.DataAnnotations;
 
     using SharpArch.Domain;
@@ -13,6 +14,7 @@
     ///     Due to the fact that .NET does not support generic attributes, this only works for entity 
     ///     types having an Id of type int.
     /// </summary> 
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
     public class HasUniqueDomainSignatureAttribute : ValidationAttribute
     {
         public HasUniqueDomainSignatureAttribute()

--- a/Solutions/SharpArch.NHibernate/NHibernateValidator/HasUniqueDomainSignatureWithGuidIdAttribute.cs
+++ b/Solutions/SharpArch.NHibernate/NHibernateValidator/HasUniqueDomainSignatureWithGuidIdAttribute.cs
@@ -7,6 +7,7 @@ namespace SharpArch.NHibernate.NHibernateValidator
     using SharpArch.Domain.DomainModel;
     using SharpArch.Domain.PersistenceSupport;
 
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
     public class HasUniqueDomainSignatureWithGuidIdAttribute : ValidationAttribute
     {
         public HasUniqueDomainSignatureWithGuidIdAttribute()

--- a/Solutions/SharpArch.NHibernate/SessionFactoryAttribute.cs
+++ b/Solutions/SharpArch.NHibernate/SessionFactoryAttribute.cs
@@ -8,7 +8,7 @@
     ///     communicate with the database.  This allows you to declare different repositories to 
     ///     communicate with different databases.
     /// </summary>
-    [AttributeUsage(AttributeTargets.Class)]
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
     public class SessionFactoryAttribute : Attribute
     {
         public readonly string FactoryKey;

--- a/Solutions/SharpArch.NHibernate/Wcf/HasUniqueDomainSignatureWithStringIdAttribute.cs
+++ b/Solutions/SharpArch.NHibernate/Wcf/HasUniqueDomainSignatureWithStringIdAttribute.cs
@@ -1,11 +1,13 @@
 namespace SharpArch.NHibernate.NHibernateValidator
 {
+    using System;
     using System.ComponentModel.DataAnnotations;
 
     using SharpArch.Domain;
     using SharpArch.Domain.DomainModel;
     using SharpArch.Domain.PersistenceSupport;
 
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
     public class HasUniqueDomainSignatureWithStringIdAttribute : ValidationAttribute
     {
         public HasUniqueDomainSignatureWithStringIdAttribute()


### PR DESCRIPTION
Although it's kind of subtle, I think it's better to have the attributes express their intended use as much as possible. This commit will cause compilation errors when applying the attribute to targets they're not intended for.
