### PR TITLE
Show the expected/requested TResult in the exception message

### DIFF
--- a/Solutions/SharpArch.Domain/Commands/CommandProcessor.cs
+++ b/Solutions/SharpArch.Domain/Commands/CommandProcessor.cs
@@ -33,7 +33,7 @@ namespace SharpArch.Domain.Commands
             var handlers = ServiceLocator.Current.GetAllInstances<ICommandHandler<TCommand, TResult>>();
             if (handlers == null || !handlers.Any())
             {
-                throw new CommandHandlerNotFoundException(typeof(TCommand));
+                throw new CommandHandlerNotFoundException(typeof(TCommand), typeof(TResult));
             }
 
             foreach (var handler in handlers)


### PR DESCRIPTION
Show more exception info by using the extended constructor in [`SharpArch.Domain.Commands.CommandHandlerNotFoundException`](https://github.com/sharparchitecture/Sharp-Architecture/blob/master/Solutions/SharpArch.Domain/Commands/CommandHandlerNotFoundException.cs).
