### PR TITLE
Extends the repositories with a method that deletes an entity from a supplied key value.

### DIFF
--- a/Solutions/SharpArch.Domain/PersistenceSupport/ILinqRepositoryWithTypedId.cs
+++ b/Solutions/SharpArch.Domain/PersistenceSupport/ILinqRepositoryWithTypedId.cs
@@ -18,6 +18,13 @@ namespace SharpArch.Domain.PersistenceSupport
         void Delete(T target);
 
         /// <summary>
+        /// Delete the object that matches the supplied id from the repository
+        /// </summary>
+        /// <typeparam name="TId">Type of Id of the entity to be deleted</typeparam>
+        /// <param name="id">Id of the entity to delete</param>
+        void Delete(TId id);
+
+        /// <summary>
         /// Save the specified object to the repository
         /// </summary>
         /// <typeparam name="T">Type of entity to save</typeparam>

--- a/Solutions/SharpArch.Domain/PersistenceSupport/IRepositoryWithTypedId.cs
+++ b/Solutions/SharpArch.Domain/PersistenceSupport/IRepositoryWithTypedId.cs
@@ -33,5 +33,10 @@ namespace SharpArch.Domain.PersistenceSupport
         /// I'll let you guess what this does.
         /// </summary>
         void Delete(T entity);
+
+        /// <summary>
+        /// Deletes the entity that matches the provided Id.
+        /// </summary>
+        void Delete(TId id);
     }
 }

--- a/Solutions/SharpArch.NHibernate/NHibernateRepositoryWithTypedId.cs
+++ b/Solutions/SharpArch.NHibernate/NHibernateRepositoryWithTypedId.cs
@@ -168,6 +168,16 @@ namespace SharpArch.NHibernate
             this.Session.Delete(entity);
         }
 
+        public virtual void Delete(TId id)
+        {
+            T entity = this.Get(id);
+
+            if (entity != null)
+            {
+                this.Delete(entity);
+            }
+        }
+
         public virtual T Get(TId id)
         {
             return this.Session.Get<T>(id);

--- a/Solutions/SharpArch.RavenDb/RavenDbRepositoryWithTypedId.cs
+++ b/Solutions/SharpArch.RavenDb/RavenDbRepositoryWithTypedId.cs
@@ -4,6 +4,7 @@ namespace SharpArch.RavenDb
     using System.Collections.Generic;
     using System.Linq;
 
+    using Raven.Abstractions.Commands;
     using Raven.Client;
 
     using SharpArch.Domain.DomainModel;
@@ -78,6 +79,11 @@ namespace SharpArch.RavenDb
         {
             this.context.Delete(entity);
             this.context.SaveChanges();
+        }
+
+        public void Delete(TIdT id)
+        {
+            this.context.Advanced.Defer(new DeleteCommandData { Key = id.ToString() });
         }
 
         public T Get(TIdT id)


### PR DESCRIPTION
This saves the caller from fetching the entity before deleting it, if only the key value is known.
