### PR TITLE
Keep NHibernate event listeners registered through xml

### DIFF
--- a/NugetTemplates/SharpArch.NHibernate/SharpArch.NHibernate.nuspec
+++ b/NugetTemplates/SharpArch.NHibernate/SharpArch.NHibernate.nuspec
@@ -14,9 +14,9 @@
     <language>en-US</language>
     <dependencies>
       <dependency id="SharpArch.Domain" version="[4.0.0,5.0.0)" />
-      <dependency id="FluentNhibernate" version="[2.0.1.0,3.0.0.0)" />
-      <dependency id="NHibernate" version="[4.0.0.0,5.0.0.0)" />
-      <dependency id="Iesi.Collections" version="[4.0.0.0,5.0.0.0)" />
+      <dependency id="FluentNhibernate" version="[2.0.3.0,3.0.0.0)" />
+      <dependency id="NHibernate" version="[4.0.4.4000,5.0.0.0)" />
+      <dependency id="Iesi.Collections" version="[4.0.1.4000,5.0.0.0)" />
     </dependencies>
   </metadata>
 </package>

--- a/NugetTemplates/SharpArch.Testing.NUnit/SharpArch.Testing.NUnit.nuspec
+++ b/NugetTemplates/SharpArch.Testing.NUnit/SharpArch.Testing.NUnit.nuspec
@@ -15,7 +15,7 @@
     <dependencies>      
       <dependency id="SharpArch.Domain" version="[4.0.0,5.0.0)" />
       <dependency id="SharpArch.NHibernate" version="[4.0.0,5.0.0)" />
-      <dependency id="NUnit" version="[2.6.4,3.0.0)" />
+      <dependency id="NUnit" version="[2.6.4,4.0.0)" />
     </dependencies>
     <frameworkAssemblies>
       <frameworkAssembly assemblyName="System.ServiceModel" targetFramework="net45" />

--- a/NugetTemplates/SharpArch.Web.Mvc.Castle/SharpArch.Web.Mvc.Castle.nuspec
+++ b/NugetTemplates/SharpArch.Web.Mvc.Castle/SharpArch.Web.Mvc.Castle.nuspec
@@ -15,7 +15,7 @@
     <dependencies>
       <dependency id="Castle.Core" version="[3.3,4.0)" />
       <dependency id="Castle.Windsor" version="[3.3,4.0)" />
-      <dependency id="Iesi.Collections" version="[4.0.0.0,5.0.0.0)" />
+      <dependency id="Iesi.Collections" version="[4.0.1.4000,5.0.0.0)" />
       <dependency id="Newtonsoft.Json" version="[6.0,7.0)" />
       <dependency id="SharpArch.Domain" version="[4.0.0,5.0.0)" />
       <dependency id="Microsoft.AspNet.Mvc" version="[5.2.3,6.0.0)" />

--- a/NugetTemplates/sharp-architecture/sharp-architecture.nuspec
+++ b/NugetTemplates/sharp-architecture/sharp-architecture.nuspec
@@ -14,7 +14,7 @@
     <language>en-US</language>
     <dependencies>
       <dependency id="SharpArch.Domain" version="[4.0.0,5.0.0)" />
-      <dependency id="SharpArch.NHibernate" version="[4.0.0,5.0.0)" />
+      <dependency id="SharpArch.NHibernate" version="[4.0.4.4000,5.0.0)" />
       <dependency id="SharpArch.Web.Mvc.Castle" version="[4.0.0,5.0.0)" />
     </dependencies>
   </metadata>

--- a/Solutions/SharpArch.NHibernate/SharpArch.NHibernate.csproj
+++ b/Solutions/SharpArch.NHibernate/SharpArch.NHibernate.csproj
@@ -46,14 +46,18 @@
     </AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FluentNHibernate">
-      <HintPath>..\..\Packages\FluentNHibernate.2.0.1.0\lib\net40\FluentNHibernate.dll</HintPath>
+    <Reference Include="FluentNHibernate, Version=2.0.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\Packages\FluentNHibernate.2.0.3.0\lib\net40\FluentNHibernate.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Iesi.Collections">
       <HintPath>..\..\Packages\Iesi.Collections.4.0.1.4000\lib\net40\Iesi.Collections.dll</HintPath>
     </Reference>
-    <Reference Include="NHibernate">
-      <HintPath>..\..\Packages\NHibernate.4.0.3.4000\lib\net40\NHibernate.dll</HintPath>
+    <Reference Include="NHibernate, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\Packages\NHibernate.4.0.4.4000\lib\net40\NHibernate.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />

--- a/Solutions/SharpArch.NHibernate/packages.config
+++ b/Solutions/SharpArch.NHibernate/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FluentNHibernate" version="2.0.1.0" targetFramework="net45" />
+  <package id="FluentNHibernate" version="2.0.3.0" targetFramework="net45" />
   <package id="Iesi.Collections" version="4.0.1.4000" targetFramework="net45" />
-  <package id="NHibernate" version="4.0.3.4000" targetFramework="net45" />
+  <package id="NHibernate" version="4.0.4.4000" targetFramework="net45" />
 </packages>

--- a/Solutions/SharpArch.Specifications/App.config
+++ b/Solutions/SharpArch.Specifications/App.config
@@ -47,7 +47,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Moq" publicKeyToken="69f491c39445e920" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.2.1502.911" newVersion="4.2.1502.911" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.1510.2205" newVersion="4.2.1510.2205" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="nunit.framework" publicKeyToken="96d09a1eb7f44a77" culture="neutral" />

--- a/Solutions/SharpArch.Specifications/SharpArch.Specifications.csproj
+++ b/Solutions/SharpArch.Specifications/SharpArch.Specifications.csproj
@@ -44,45 +44,51 @@
     </AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FluentNHibernate">
-      <HintPath>..\..\Packages\FluentNHibernate.2.0.1.0\lib\net40\FluentNHibernate.dll</HintPath>
+    <Reference Include="FluentNHibernate, Version=2.0.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\Packages\FluentNHibernate.2.0.3.0\lib\net40\FluentNHibernate.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Iesi.Collections">
       <HintPath>..\..\Packages\Iesi.Collections.4.0.1.4000\lib\net40\Iesi.Collections.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Machine.Specifications">
-      <HintPath>..\..\Packages\Machine.Specifications.0.9.1\lib\net45\Machine.Specifications.dll</HintPath>
+    <Reference Include="Machine.Specifications, Version=0.9.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\Packages\Machine.Specifications.0.9.3\lib\net45\Machine.Specifications.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Machine.Specifications.AutoMocking">
       <HintPath>..\..\Packages\Machine.Specifications.AutoMocking.1.5.10.2\lib\Machine.Specifications.AutoMocking.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Machine.Specifications.Clr4">
-      <HintPath>..\..\Packages\Machine.Specifications.0.9.1\lib\net45\Machine.Specifications.Clr4.dll</HintPath>
+    <Reference Include="Machine.Specifications.Clr4, Version=0.9.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\Packages\Machine.Specifications.0.9.3\lib\net45\Machine.Specifications.Clr4.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Machine.Specifications.Mvc">
       <HintPath>..\..\Packages\Machine.Specifications.Mvc5.1.6.1.0\lib\Machine.Specifications.Mvc.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Machine.Specifications.Should">
-      <HintPath>..\..\Packages\Machine.Specifications.Should.0.7.2\lib\net45\Machine.Specifications.Should.dll</HintPath>
+    <Reference Include="Machine.Specifications.Should, Version=0.8.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\Packages\Machine.Specifications.Should.0.8.0\lib\net45\Machine.Specifications.Should.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Practices.ServiceLocation">
       <HintPath>..\..\Packages\CommonServiceLocator.1.3\lib\portable-net4+sl5+netcore45+wpa81+wp8\Microsoft.Practices.ServiceLocation.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Moq, Version=4.2.1502.911, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+    <Reference Include="Moq, Version=4.2.1510.2205, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\Packages\Moq.4.2.1502.0911\lib\net40\Moq.dll</HintPath>
+      <HintPath>..\..\Packages\Moq.4.2.1510.2205\lib\net40\Moq.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="NHibernate, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\Packages\NHibernate.4.0.3.4000\lib\net40\NHibernate.dll</HintPath>
+      <HintPath>..\..\Packages\NHibernate.4.0.4.4000\lib\net40\NHibernate.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework">
       <HintPath>..\..\Packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>

--- a/Solutions/SharpArch.Specifications/packages.config
+++ b/Solutions/SharpArch.Specifications/packages.config
@@ -1,14 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CommonServiceLocator" version="1.3" targetFramework="net45" />
-  <package id="FluentNHibernate" version="2.0.1.0" targetFramework="net45" />
+  <package id="FluentNHibernate" version="2.0.3.0" targetFramework="net45" />
   <package id="Iesi.Collections" version="4.0.1.4000" targetFramework="net45" />
-  <package id="Machine.Specifications" version="0.9.1" targetFramework="net45" />
+  <package id="Machine.Specifications" version="0.9.3" targetFramework="net45" />
   <package id="Machine.Specifications.AutoMocking" version="1.5.10.2" targetFramework="net45" />
   <package id="Machine.Specifications.Mvc5" version="1.6.1.0" targetFramework="net45" />
-  <package id="Machine.Specifications.Should" version="0.7.2" targetFramework="net45" />
-  <package id="Moq" version="4.2.1502.0911" targetFramework="net45" />
-  <package id="NHibernate" version="4.0.3.4000" targetFramework="net45" />
+  <package id="Machine.Specifications.Should" version="0.8.0" targetFramework="net45" />
+  <package id="Moq" version="4.2.1510.2205" targetFramework="net45" />
+  <package id="NHibernate" version="4.0.4.4000" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
   <package id="RhinoMocks" version="3.6.1" targetFramework="net45" />
   <package id="System.Data.SQLite.Core" version="1.0.96.0" targetFramework="net45" />

--- a/Solutions/SharpArch.Testing.NUnit/SharpArch.Testing.NUnit.csproj
+++ b/Solutions/SharpArch.Testing.NUnit/SharpArch.Testing.NUnit.csproj
@@ -64,14 +64,17 @@
     <DocumentationFile>bin\Release\SharpArch.Testing.NUnit.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="FluentNHibernate">
-      <HintPath>..\..\Packages\FluentNHibernate.2.0.1.0\lib\net40\FluentNHibernate.dll</HintPath>
+    <Reference Include="FluentNHibernate, Version=2.0.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\Packages\FluentNHibernate.2.0.3.0\lib\net40\FluentNHibernate.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Iesi.Collections">
       <HintPath>..\..\Packages\Iesi.Collections.4.0.1.4000\lib\net40\Iesi.Collections.dll</HintPath>
     </Reference>
-    <Reference Include="NHibernate">
-      <HintPath>..\..\Packages\NHibernate.4.0.3.4000\lib\net40\NHibernate.dll</HintPath>
+    <Reference Include="NHibernate, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\Packages\NHibernate.4.0.4.4000\lib\net40\NHibernate.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework">

--- a/Solutions/SharpArch.Testing.NUnit/packages.config
+++ b/Solutions/SharpArch.Testing.NUnit/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FluentNHibernate" version="2.0.1.0" targetFramework="net45" />
+  <package id="FluentNHibernate" version="2.0.3.0" targetFramework="net45" />
   <package id="Iesi.Collections" version="4.0.1.4000" targetFramework="net45" />
-  <package id="NHibernate" version="4.0.3.4000" targetFramework="net45" />
+  <package id="NHibernate" version="4.0.4.4000" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
 </packages>

--- a/Solutions/SharpArch.Tests/SharpArch.NHibernate/NHibernateSessionFactoryBuilderTests.cs
+++ b/Solutions/SharpArch.Tests/SharpArch.NHibernate/NHibernateSessionFactoryBuilderTests.cs
@@ -1,4 +1,7 @@
-﻿namespace Tests.SharpArch.NHibernate
+﻿using FluentAssertions;
+using SharpArch.Testing.NUnit;
+
+namespace Tests.SharpArch.NHibernate
 {
     using System;
     using System.IO;
@@ -84,5 +87,34 @@
                         .BuildConfiguration();
                 });
         }
+
+        [Test]
+        public void WhenUsingDataAnnotationValidators_ShouldKeepRegisteredPreInsertEventListeners()
+        {
+
+            var configFile = "sqlite-nhibernate-config.xml";
+
+            var configuration = new NHibernateSessionFactoryBuilder()
+                .UseConfigFile(configFile)
+                .UseDataAnnotationValidators(true)
+                .BuildConfiguration();
+
+            configuration.EventListeners.PreInsertEventListeners.Should().Contain(l => l is PreInsertListener);
+        }
+
+        [Test]
+        public void WhenUsingDataAnnotationValidators_ShouldKeepRegisteredPreUpdateEventListeners()
+        {
+
+            var configFile = "sqlite-nhibernate-config.xml";
+
+            var configuration = new NHibernateSessionFactoryBuilder()
+                .UseConfigFile(configFile)
+                .UseDataAnnotationValidators(true)
+                .BuildConfiguration();
+
+            configuration.EventListeners.PreUpdateEventListeners.Should().Contain(l => l is PreUpdateListener);
+        }
+
     }
 }

--- a/Solutions/SharpArch.Tests/SharpArch.NHibernate/PreInsertlistener.cs
+++ b/Solutions/SharpArch.Tests/SharpArch.NHibernate/PreInsertlistener.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using NHibernate.Event;
+
+namespace Tests.SharpArch.NHibernate
+{
+    [Serializable]
+    public class PreInsertListener : IPreInsertEventListener
+    {
+        public bool OnPreInsert(PreInsertEvent @event)
+        {
+            return true;
+        }
+    }
+
+    [Serializable]
+    public class PreUpdateListener : IPreUpdateEventListener
+    {
+        public bool OnPreUpdate(PreUpdateEvent @event)
+        {
+            return true;
+        }
+    }
+}

--- a/Solutions/SharpArch.Tests/SharpArch.Tests.csproj
+++ b/Solutions/SharpArch.Tests/SharpArch.Tests.csproj
@@ -74,16 +74,19 @@
       <HintPath>..\..\Packages\CommonServiceLocator.WindsorAdapter.1.0\lib\NET35\CommonServiceLocator.WindsorAdapter.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="FluentAssertions, Version=3.3.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
-      <HintPath>..\..\Packages\FluentAssertions.3.3.0\lib\net45\FluentAssertions.dll</HintPath>
+    <Reference Include="FluentAssertions, Version=4.1.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\Packages\FluentAssertions.4.1.0\lib\net45\FluentAssertions.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="FluentAssertions.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
-      <HintPath>..\..\Packages\FluentAssertions.3.3.0\lib\net45\FluentAssertions.Core.dll</HintPath>
+    <Reference Include="FluentAssertions.Core, Version=4.1.0.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\Packages\FluentAssertions.4.1.0\lib\net45\FluentAssertions.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="FluentNHibernate">
-      <HintPath>..\..\Packages\FluentNHibernate.2.0.1.0\lib\net40\FluentNHibernate.dll</HintPath>
+    <Reference Include="FluentNHibernate, Version=2.0.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\Packages\FluentNHibernate.2.0.3.0\lib\net40\FluentNHibernate.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Iesi.Collections">
@@ -98,9 +101,10 @@
       <HintPath>..\..\Packages\Microsoft.Web.Infrastructure.1.0.0.0\lib\net40\Microsoft.Web.Infrastructure.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Moq, Version=4.2.1502.911, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+    <Reference Include="Moq, Version=4.2.1510.2205, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\Packages\Moq.4.2.1502.0911\lib\net40\Moq.dll</HintPath>
+      <HintPath>..\..\Packages\Moq.4.2.1510.2205\lib\net40\Moq.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
@@ -108,7 +112,8 @@
     </Reference>
     <Reference Include="NHibernate, Version=4.0.0.4000, Culture=neutral, PublicKeyToken=aa95f207798dfdb4, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\Packages\NHibernate.4.0.3.4000\lib\net40\NHibernate.dll</HintPath>
+      <HintPath>..\..\Packages\NHibernate.4.0.4.4000\lib\net40\NHibernate.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework">
       <HintPath>..\..\Packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
@@ -167,6 +172,7 @@
     <Compile Include="SharpArch.Domain\DomainModel\ValueObjectTests.cs" />
     <Compile Include="SharpArch.Domain\Reflection\TypePropertyDescriptorCacheTests.cs" />
     <Compile Include="SharpArch.NHibernate\NHibernateSessionFactoryBuilderTests.cs" />
+    <Compile Include="SharpArch.NHibernate\PreInsertListener.cs" />
     <Compile Include="SharpArch.NHibernate\RepositoryTests.cs" />
     <Compile Include="SharpArch.NHibernate\RepositoryTestsHelper.cs" />
     <Compile Include="SharpArch.NHibernate\SafeServiceLocatorTests.cs" />
@@ -221,6 +227,7 @@
   <ItemGroup>
     <Content Include="sqlite-nhibernate-config.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <SubType>Designer</SubType>
     </Content>
   </ItemGroup>
   <ItemGroup>

--- a/Solutions/SharpArch.Tests/packages.config
+++ b/Solutions/SharpArch.Tests/packages.config
@@ -4,16 +4,16 @@
   <package id="Castle.Windsor" version="3.3.0" targetFramework="net45" />
   <package id="CommonServiceLocator" version="1.3" targetFramework="net45" />
   <package id="CommonServiceLocator.WindsorAdapter" version="1.0" targetFramework="net45" />
-  <package id="FluentAssertions" version="3.3.0" targetFramework="net45" />
-  <package id="FluentNHibernate" version="2.0.1.0" targetFramework="net45" />
+  <package id="FluentAssertions" version="4.1.0" targetFramework="net45" />
+  <package id="FluentNHibernate" version="2.0.3.0" targetFramework="net45" />
   <package id="Iesi.Collections" version="4.0.1.4000" targetFramework="net45" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.3" targetFramework="net45" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net45" />
-  <package id="Moq" version="4.2.1502.0911" targetFramework="net45" />
+  <package id="Moq" version="4.2.1510.2205" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
-  <package id="NHibernate" version="4.0.3.4000" targetFramework="net45" />
+  <package id="NHibernate" version="4.0.4.4000" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
   <package id="System.Data.SQLite.Core" version="1.0.96.0" targetFramework="net45" />
 </packages>

--- a/Solutions/SharpArch.Tests/sqlite-nhibernate-config.xml
+++ b/Solutions/SharpArch.Tests/sqlite-nhibernate-config.xml
@@ -2,6 +2,7 @@
 
 <hibernate-configuration xmlns="urn:nhibernate-configuration-2.2">
   <session-factory>
+
     <property name="dialect">
       NHibernate.Dialect.SQLiteDialect
     </property>
@@ -13,5 +14,13 @@
     </property>
     <property name="connection.release_mode">on_close</property>
     <property name="show_sql">true</property>
+
+    <event type="pre-insert">
+      <listener class="Tests.SharpArch.NHibernate.PreInsertListener, SharpArch.Tests" />
+    </event>
+    <event type="pre-update">
+      <listener class="Tests.SharpArch.NHibernate.PreUpdateListener, SharpArch.Tests" />
+    </event>
+
   </session-factory>
 </hibernate-configuration>

--- a/VersionHistory.txt
+++ b/VersionHistory.txt
@@ -2,17 +2,30 @@
 S#arp vNext
 ========================
 
-* #124 BREAKING: removed Command/Query infrastructure;
+Breaking changes:
+ * target platform is .NET 4.5;
+ * #124 BREAKING: removed Command/Query infrastructure;
+
+
+Fixes:
+ * #54 - NHibernate event listeners registered through xml gets removed;
+
+New features:
+ * ASP.NET MVC Filter property injection with Castle;
+
+Changes:
+ * Samples are now part of main repository;
+
 
 Updated dependencies
 ------
 
 CommonServiceLocator 1.3^
 Newtonsoft.Json 6.0.8^
-FluentNHibernate 2.0.1^
+FluentNHibernate 2.0.3^
 Iesi.Collections4.0.1.4000^
 ASP.NVC MVC 5.2^
-NHibernate 4.0.3.4000^
+NHibernate 4.0.4.4000^
 RavenDB.Client 3.0.3528^
 Castle.Core 3.3.3^
 Castle.Windsor 3.3.0^


### PR DESCRIPTION
Make sure event listeners are not removed when using Data Annotation validators.
Update dependencies, fix #54.
