### PR TITLE
Override cake tools path in build.sh

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -84,6 +84,7 @@ var nugetExe = "./tools/nuget.exe";
 
 Setup((context) =>
 {
+    DotNetCoreBuildServerShutdown();
     Information("Building SharpArchitecture, version {0} (isTagged: {1}, isLocal: {2})...", nugetVersion, isTagged, local);
     CreateDirectory(artifactsDir);
     CleanDirectory(artifactsDir);

--- a/build.sh
+++ b/build.sh
@@ -114,4 +114,4 @@ if [ ! -f "$CAKE_EXE" ]; then
 fi
 
 # Start Cake
-exec mono "$CAKE_EXE" $SCRIPT "${CAKE_ARGUMENTS[@]}"
+exec mono "$CAKE_EXE" "$SCRIPT" "--paths_tools=/tmp/tools" "${CAKE_ARGUMENTS[@]}"


### PR DESCRIPTION
The value in cake.config is for windows only and can't see how to
configure it to be multiplatform. Setting the paths_tools parameter
overrides the config value and allows cake to run so that AssemblyInfo
files are generated.