### PR TITLE
Update readthedocs config and generate markdown

### DIFF
--- a/Artefacts/Documentation/Makefile
+++ b/Artefacts/Documentation/Makefile
@@ -66,6 +66,11 @@ json:
 	@echo
 	@echo "Build finished; now you can process the JSON files."
 
+markdown:
+	$(SPHINXBUILD) -b markdown $(ALLSPHINXOPTS) $(BUILDDIR)/markdown
+	@echo
+	@echo "Build finished; now you can process the JSON files."
+
 htmlhelp:
 	$(SPHINXBUILD) -b htmlhelp $(ALLSPHINXOPTS) $(BUILDDIR)/htmlhelp
 	@echo

--- a/Artefacts/Documentation/requirements.txt
+++ b/Artefacts/Documentation/requirements.txt
@@ -1,0 +1,12 @@
+Pygments==2.3.1
+setuptools==41.0.1
+docutils==0.14
+mock==1.0.1
+pillow==5.4.1
+alabaster>=0.7,<0.8,!=0.7.5
+commonmark==0.8.1
+recommonmark==0.5.0
+sphinx<2
+sphinx-rtd-theme<0.5
+readthedocs-sphinx-ext<1.1
+sphinx-markdown-builder==0.5.3

--- a/Artefacts/Documentation/source/conf.py
+++ b/Artefacts/Documentation/source/conf.py
@@ -34,7 +34,7 @@ if not on_rtd:  # only import and set the theme if we're building docs locally
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['sphinx.ext.intersphinx', 'sphinx.ext.todo']
+extensions = ['sphinx.ext.intersphinx', 'sphinx.ext.todo', 'sphinx_markdown_builder']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -73,7 +73,9 @@ release = '2.1rc'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = []
+exclude_patterns = [
+    'build/*'
+]
 
 # The reST default role (used for this markup: `text`) to use for all documents.
 #default_role = None

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,0 +1,23 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: Artefacts/Documentation/source/conf.py
+
+# Build documentation with MkDocs
+#mkdocs:
+#  configuration: mkdocs.yml
+
+# Optionally build your docs in additional formats such as PDF and ePub
+formats: all
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+  version: 3.7
+  install:
+    - requirements: Artefacts/Documentation/requirements.txt


### PR DESCRIPTION
Looks like read the docs configs were way out of date and missing some
stuff, updated config in the ui, ran build and put into the project as readthedocs.yml.

Added support to generate markdown file in case we decide to move into
that.